### PR TITLE
[#4] delete SNS anchor at footer

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -11,8 +11,6 @@ function Footer() {
             <p css={copyrightStyle}>DogVelopers. All rights reserved.</p>
           </div>
           <div css={rightStyle}>
-            <a href="instagram.com">Instagram</a>
-            <a href="instagram.com">Facebook</a>
             <a href="mailto:mail.dogvelopers@gmail.com">Email</a>
           </div>
         </div>


### PR DESCRIPTION
### 설명

개발자들 SNS가 아직 없기때문에 footer의 SNS 링크 태그를 삭제했습니당

### 자세히 봐줬으면 하는 부분
