### PR TITLE
모바일 사이즈 확대

### DIFF
--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -15,7 +15,7 @@ const theme: Theme = {
   },
   mediaQuery: {
     tablet: '@media (max-width: 830px)',
-    mobile: '@media (max-width: 425px)',
+    mobile: '@media (max-width: 430px)',
   },
 };
 


### PR DESCRIPTION
### 설명

[Hotjar recording 영상](https://insights.hotjar.com/r?site=2816776&recording=10763972134&startTime=1000&token=deea5d3a02afa33a5f4cebb35e0f80a6) 에서 확인하여 428 사이즈 (아이폰 프로 맥스)에서 반응형 적용이 안되는 것을 확인하여 수정하였습니다.

### 자세히 봐줬으면 하는 부분
